### PR TITLE
Fix voice recognition missing this.props after arrow function removed

### DIFF
--- a/lib/VoicePlayer.js
+++ b/lib/VoicePlayer.js
@@ -16,7 +16,7 @@ class VoicePlayer extends Component {
     }
   }
 
-  createSpeech = () => {
+  createSpeech () {
     const defaults = {
       text: '',
       volume: 1,
@@ -25,29 +25,35 @@ class VoicePlayer extends Component {
       lang: 'en-US'
     }
 
+    const options = Object.assign({}, defaults, this.props)
+
     let speech = new SpeechSynthesisUtterance()
 
-    Object.assign(speech, defaults, this.props)
+    speech.text = options.text
+    speech.volume = options.volume
+    speech.rate = options.rate
+    speech.pitch = options.pitch
+    speech.lang = options.lang
 
     return speech
   }
 
-  speak = () => {
+  speak () {
     window.speechSynthesis.speak(this.speech)
     this.setState({ started: true, playing: true })
   }
 
-  cancel = () => {
+  cancel () {
     window.speechSynthesis.cancel()
     this.setState({ started: false, playing: false })
   }
 
-  pause = () => {
+  pause () {
     window.speechSynthesis.pause()
     this.setState({ playing: false })
   }
 
-  resume = () => {
+  resume () {
     window.speechSynthesis.resume()
     this.setState({ playing: true })
   }
@@ -98,4 +104,3 @@ class VoicePlayer extends Component {
 }
 
 export default VoicePlayer
-

--- a/lib/VoiceRecognition.js
+++ b/lib/VoiceRecognition.js
@@ -17,21 +17,25 @@ class VoiceRecognition extends Component {
     }
   }
 
-  createRecognition = (SpeechRecognition) => {
+  createRecognition(SpeechRecognition){
     const defaults = {
       continuous: true,
       interimResults: false,
       lang: 'en-US'
     }
 
+    const options = Object.assign({}, defaults, this.props)
+
     let recognition = new SpeechRecognition()
-    
-    Object.assign(recognition, defaults, this.props)
+
+    recognition.continuous = options.continuous
+    recognition.interimResults = options.interimResults
+    recognition.lang = options.lang
 
     return recognition
   }
 
-  bindResult = (event) => {
+  bindResult (event) {
     let interimTranscript = ''
     let finalTranscript = ''
 
@@ -46,15 +50,15 @@ class VoiceRecognition extends Component {
     this.props.onResult({ interimTranscript, finalTranscript })
   }
 
-  start = () => {
+  start () {
     this.recognition.start()
   }
 
-  stop = () => {
+  stop () {
     this.recognition.stop()
   }
 
-  abort = () => {
+  abort () {
     this.recognition.abort()
   }
 
@@ -90,4 +94,3 @@ class VoiceRecognition extends Component {
 }
 
 export default VoiceRecognition
-

--- a/lib/VoiceRecognition.js
+++ b/lib/VoiceRecognition.js
@@ -35,7 +35,7 @@ class VoiceRecognition extends Component {
     return recognition
   }
 
-  bindResult (event) {
+  bindResult (props, event) {
     let interimTranscript = ''
     let finalTranscript = ''
 
@@ -47,7 +47,7 @@ class VoiceRecognition extends Component {
       }
     }
 
-    this.props.onResult({ interimTranscript, finalTranscript })
+    props.onResult({ interimTranscript, finalTranscript })
   }
 
   start () {
@@ -79,7 +79,7 @@ class VoiceRecognition extends Component {
       this.recognition.addEventListener(event.name, event.action)
     })
 
-    this.recognition.addEventListener('result', this.bindResult)
+    this.recognition.addEventListener('result', this.bindResult.bind(null,this.props), false)
 
     this.start()
   }


### PR DESCRIPTION
The fix that removed arrow functions to be compatible with common js changed the scope for `this` in the bindResult method. Now props are bound to the eventListener and sent as an argument